### PR TITLE
Fix result buffer results and rename method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Using lazy package manager:
 
 #### Available commands
 
-| Command | Description |
-| --- | --- |
-| AddProjectReference | Adds a project reference of one project to another |
-| AddPackagesToProject | Add a nuget package to a project |
-| UpdatePackagesInSolution | Update all nuget packages in the chosen project |
+| Command                  | Description                                        |
+| ------------------------ | -------------------------------------------------- |
+| AddProjectReference      | Adds a project reference of one project to another |
+| AddPackagesToProject     | Add a nuget package to a project                   |
+| UpdatePackagesInSolution | Update all nuget packages in the chosen project    |
 
 #### TODO
 
@@ -40,5 +40,5 @@ Using lazy package manager:
 - [ ] Add some kind of progress buffer when updating all nugets
 - [ ] Make sure directory.packages.config works, also make sure it works without that file
 - [ ] Make UpdatePackagesInSolution really update all packages in the solution
-- [ ] Make another command called UpdatePackagesInProject that updates all packages in the chosen project
+- [x] Make another command called UpdatePackagesInProject that updates all packages in the chosen project
 - [ ] Make the command ProjektGunnar and instead take e.g. AddProjectReference as input to avoid clogging up the commands

--- a/lua/projektgunnar/init.lua
+++ b/lua/projektgunnar/init.lua
@@ -23,9 +23,15 @@ vim.api.nvim_create_user_command(
 )
 
 vim.api.nvim_create_user_command(
-	"UpdatePackagesInSolution",
-	nugets.update_packages_in_solution,
+	"UpdatePackagesInProject",
+	nugets.update_packages_in_project,
 	{ desc = "Update nugets in project" }
 )
+
+-- vim.api.nvim_create_user_command(
+-- 	"UpdatePackagesInSolution",
+-- 	nugets.update_packages_in_solution,
+-- 	{ desc = "Update nugets in solution" }
+-- )
 
 return M

--- a/lua/projektgunnar/nugets.lua
+++ b/lua/projektgunnar/nugets.lua
@@ -24,7 +24,7 @@ function M.add_packages_to_project()
 	utils.open_result_buffer(resultOfNugetAdd, output_regex)
 end
 
-function M.update_packages_in_solution()
+function M.update_packages_in_project()
 	local projects = utils.get_all_projects_in_solution()
 
 	-- ask user to select a project

--- a/lua/projektgunnar/utils.lua
+++ b/lua/projektgunnar/utils.lua
@@ -50,13 +50,10 @@ function M.open_result_buffer(results, output_regex_table)
 	local lines_with_errors = M.get_lines_from_table(lines, output_regex_table.error)
 
 	-- Set the buffer's content
-	if #lines_with_errors > 0 then
-		vim.api.nvim_buf_set_lines(result_buffer, 0, -1, false, lines_with_errors)
-	else
-		-- get the lines containing the word PackageReference for package updated
-		local lines_with_package_reference = M.get_lines_from_table(lines, output_regex_table.success)
-		vim.api.nvim_buf_set_lines(result_buffer, 0, -1, false, lines_with_package_reference)
-	end
+	-- get the lines containing the word PackageReference for package updated
+	local lines_with_package_reference =
+		M.concatenate_tables(M.get_lines_from_table(lines, output_regex_table.success), lines_with_errors)
+	vim.api.nvim_buf_set_lines(result_buffer, 0, -1, false, lines_with_package_reference)
 
 	-- Set the buffer to be unmodifiable
 	vim.api.nvim_buf_set_option(result_buffer, "modifiable", false)
@@ -84,6 +81,22 @@ function M.get_all_projects_in_solution()
 	end
 
 	return projects
+end
+
+-- function that concatenates tables, make sure that the tables are not nil
+function M.concatenate_tables(table1, table2)
+	local concatenated_table = {}
+	if table1 ~= nil then
+		for _, value in ipairs(table1) do
+			table.insert(concatenated_table, value)
+		end
+	end
+	if table2 ~= nil then
+		for _, value in ipairs(table2) do
+			table.insert(concatenated_table, value)
+		end
+	end
+	return concatenated_table
 end
 
 return M


### PR DESCRIPTION
Make sure result buffer shows both successful messages and error messages as there might be both successful and failed updates to nugets.

Also rename update nuget method as it updated a project, not entire solution.