### PR TITLE
Fix: Projects not found

### DIFF
--- a/lua/projektgunnar/dotnet_jobs.lua
+++ b/lua/projektgunnar/dotnet_jobs.lua
@@ -38,8 +38,9 @@ local function run_queue(buf, command_and_items)
 
 				-- Update per-item status in the floating window
 				local success = (code == 0)
+				local package = argv[#argv]
 				local argsToPrint = table.concat(argv or {}, " ")
-				async.ui(ui.result.update, buf, ii, total_items, success, argsToPrint)
+				async.ui(ui.result.update, buf, ii, total_items, success, argsToPrint, package)
 			end
 		end
 

--- a/lua/projektgunnar/nugets.lua
+++ b/lua/projektgunnar/nugets.lua
@@ -84,10 +84,6 @@ end
 -- Your async.wrap_cb appends resume as the LAST arg; we MUST pass opts explicitly.
 local run_dotnet_list_direct = async.wrap_cb(run_dotnet_list)
 
-----------------------------------------------------------------------
--- Public API
-----------------------------------------------------------------------
-
 --- List all NuGet packages in a project.
 --- @param project string
 --- @param opts { cwd?: string, text?: boolean }|nil

--- a/lua/projektgunnar/ui.lua
+++ b/lua/projektgunnar/ui.lua
@@ -5,10 +5,6 @@ local M = {
 	result = {},
 }
 
--- ======================
--- Utils: sizing/centering
--- ======================
-
 -- Return drawable editor size (accounts for cmdheight/tabline properly)
 local function editor_size()
 	local ui = api.nvim_list_uis()[1]
@@ -45,10 +41,6 @@ local function center_line(s)
 	return string.rep(" ", pad) .. s
 end
 
--- ======================
--- Utils: safe buffer edits
--- ======================
-
 --- Temporarily set modifiable, run fn, then restore original state
 local function with_modifiable(buf, fn)
 	local prev = vim.bo[buf].modifiable
@@ -74,10 +66,6 @@ local function append_lines(buf, lines)
 		api.nvim_buf_set_lines(buf, 0, -1, false, vim.list_extend(curr, lines))
 	end)
 end
-
--- ======================
--- Floats: single-window with built-in border/title
--- ======================
 
 --- Open a floating window with built-in border/title (no separate border buffer)
 --- @param opts table nvim_open_win config overrides (width/height/row/col required)
@@ -149,10 +137,6 @@ local function recenter_on_resize(win, width, height)
 		end,
 	})
 end
-
--- ======================
--- Spinner: dedicated line, timer-based, idempotent cleanup
--- ======================
 
 -- Active spinner state (only present while running)
 --   spinners[buf] = { timer = uv_timer, idx = int, line = int }
@@ -261,10 +245,6 @@ local function spinner_stop(buf)
 	safe_close_timer(s.timer)
 	spinners[buf] = nil
 end
-
--- ======================
--- Public API: Input popup
--- ======================
 
 --- Open a centered one-line input popup (title in border; buffer is editable)
 --- @param on_confirm fun(text: string)
@@ -417,12 +397,14 @@ end
 --- @param total integer
 --- @param success boolean
 --- @param cmd string
-function M.result.update(buf, index, total, success, cmd)
+--- @param package string
+function M.result.update(buf, index, total, success, cmd, package)
 	local status_symbol = success and "" or ""
 	local status_message = success and "Success" or "Failed"
 	append_lines(buf, {
 		tostring(index) .. " out of " .. tostring(total),
 		"Status: " .. status_message .. " " .. status_symbol,
+		"Package: " .. package,
 		"Command: " .. cmd,
 		"----------------------------------------",
 	})

--- a/lua/projektgunnar/utils.lua
+++ b/lua/projektgunnar/utils.lua
@@ -74,8 +74,20 @@ end
 function M.get_all_projects_in_solution(sln_path)
 	local output = vim.fn.systemlist({ "dotnet", "sln", sln_path, "list" })
 
-	-- remove the first two lines from the output as they are Projects and ----------
-	return vim.list_slice(output, 3, #output)
+	local rows = vim.list_slice(output, 3, #output)
+
+	local sln_dir = vim.fs.dirname(sln_path)
+
+	local result = {}
+	for _, p in ipairs(rows) do
+		local rel = vim.trim(p):gsub("\r", "")
+		if rel ~= "" then
+			local abs = vim.fs.normalize(vim.fs.joinpath(sln_dir, rel))
+			table.insert(result, abs)
+		end
+	end
+
+	return result
 end
 
 --- returns all projects that are not already in the solution file

--- a/lua/projektgunnar/utils.lua
+++ b/lua/projektgunnar/utils.lua
@@ -74,6 +74,7 @@ end
 function M.get_all_projects_in_solution(sln_path)
 	local output = vim.fn.systemlist({ "dotnet", "sln", sln_path, "list" })
 
+	-- Remove the first 2 rows as those are Projects and ----------
 	local rows = vim.list_slice(output, 3, #output)
 
 	local sln_dir = vim.fs.dirname(sln_path)

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -203,7 +203,7 @@ describe("utils", function()
 			local sln = "/repo/MySolution.sln"
 			local result = utils.get_all_projects_in_solution(sln)
 
-			assert.are.same({ "proj1.csproj", "proj2.csproj" }, result)
+			assert.are.same({ "/repo/proj1.csproj", "/repo/proj2.csproj" }, result)
 			assert.stub(systemlist_stub).was_called_with({ "dotnet", "sln", sln, "list" })
 		end)
 


### PR DESCRIPTION
There was an issue where sln was not in cwd but assumed that csproj were.

Fix by handling all projects as absolute paths rather than relative.